### PR TITLE
Add unicode path support and persist UI settings

### DIFF
--- a/bright_field_processor.py
+++ b/bright_field_processor.py
@@ -5,22 +5,22 @@ import numpy as np
 
 def process_bright_field(img_bf_gray, thresh_bf, show_mask=True):
     """
-    明場影像處理：
-    - 輸入：灰階明場影像、threshold、是否顯示 mask
-    - 輸出：
-        view_bf_bgr: 要在 BF viewer 顯示的 BGR 圖
-        mask_bf: 0/255 的二值 mask（瑕疵 + 灰塵）
+    Bright field image processing:
+    - Input: grayscale BF image, threshold, whether to show mask
+    - Output:
+        view_bf_bgr: BGR image for the BF viewer
+        mask_bf: binary mask for defects and dust (0/255)
     """
     if img_bf_gray is None:
         return None, None
 
-    # 二值化
+    # Binary mask
     _, mask_bf = cv2.threshold(img_bf_gray, thresh_bf, 255, cv2.THRESH_BINARY)
 
-    # 顯示用 BGR
+    # BGR image for display
     view_bf_bgr = cv2.cvtColor(img_bf_gray, cv2.COLOR_GRAY2BGR)
     if show_mask:
-        # 用紅色標記 BF mask
+        # Mark BF mask in red
         view_bf_bgr[mask_bf == 255] = [0, 0, 255]
 
     return view_bf_bgr, mask_bf

--- a/dark_field_processor.py
+++ b/dark_field_processor.py
@@ -6,30 +6,30 @@ import numpy as np
 def process_dark_field(img_df_gray, thresh_df, show_mask=True,
                        ksize=3, iters=1):
     """
-    暗場影像處理：
-    - 輸入：灰階暗場影像、threshold、是否顯示 mask、膨脹 kernel / iterations
-    - 輸出：
-        view_df_bgr: 要在 DF viewer 顯示的 BGR 圖
-        mask_df_raw: 原始 threshold 後的 DF mask
-        mask_df_dilated: 膨脹後的 DF mask（iter=0 或 ksize<=1 則與 raw 相同）
+    Dark field image processing:
+    - Input: grayscale DF image, threshold, whether to show mask, dilation kernel size/iterations
+    - Output:
+        view_df_bgr: BGR image for the DF viewer
+        mask_df_raw: raw DF mask after thresholding
+        mask_df_dilated: dilated DF mask (same as raw when iter=0 or ksize<=1)
     """
     if img_df_gray is None:
         return None, None, None
 
-    # 1. 二值化
+    # 1. Thresholding
     _, mask_df_raw = cv2.threshold(img_df_gray, thresh_df, 255, cv2.THRESH_BINARY)
 
-    # 2. 膨脹處理（iterations=0 表示不做膨脹）
+    # 2. Dilation (iterations=0 means skip dilation)
     if iters > 0 and ksize > 1:
         kernel = np.ones((ksize, ksize), np.uint8)
         mask_df_dilated = cv2.dilate(mask_df_raw, kernel, iterations=iters)
     else:
         mask_df_dilated = mask_df_raw
 
-    # 3. 顯示用 BGR（暗場 viewer 顯示的是膨脹後的結果）
+    # 3. BGR image for display (viewer uses the dilated result)
     view_df_bgr = cv2.cvtColor(img_df_gray, cv2.COLOR_GRAY2BGR)
     if show_mask:
-        # 用綠色標記 DF mask（膨脹後）
+        # Mark the dilated DF mask in green
         view_df_bgr[mask_df_dilated == 255] = [0, 255, 0]
 
     return view_df_bgr, mask_df_raw, mask_df_dilated

--- a/sync_image_viewer.py
+++ b/sync_image_viewer.py
@@ -6,14 +6,14 @@ from PySide6.QtWidgets import QWidget
 
 class SyncImageViewer(QWidget):
     """
-    影像顯示視窗：
-    - 左鍵拖曳：平移
-    - 滾輪：縮放（以滑鼠位置為中心）
-    - 多個 Viewer 共用 shared_state，實現同步平移 / 縮放
-    - mouse_info 回報滑鼠對應的顯示影像座標
+    Image display widget:
+    - Left mouse drag: pan
+    - Mouse wheel: zoom (centered on cursor position)
+    - Multiple viewers share shared_state for synchronized pan/zoom
+    - mouse_info emits the mapped image coordinates for the cursor
     """
     mouse_info = Signal(str, float, float, bool)     # view_key, img_x, img_y, inside
-    transform_changed = Signal()                     # 平移/縮放變化時發出
+    transform_changed = Signal()                     # Emitted when pan/zoom changes
 
     def __init__(self, view_key, shared_state, parent=None):
         super().__init__(parent)
@@ -82,7 +82,7 @@ class SyncImageViewer(QWidget):
 
         old_scale = self.shared_state.get("scale", 1.0)
         new_scale = old_scale * factor
-        new_scale = max(0.05, min(20.0, new_scale))  # 限制縮放範圍
+        new_scale = max(0.05, min(20.0, new_scale))  # Limit zoom range
 
         if abs(new_scale - old_scale) < 1e-6:
             return
@@ -130,7 +130,7 @@ class SyncImageViewer(QWidget):
         pos = event.position()
 
         if event.buttons() & Qt.LeftButton and self.last_mouse_pos is not None:
-            # 平移
+            # Pan
             delta = pos - self.last_mouse_pos
             self.last_mouse_pos = pos
 
@@ -143,7 +143,7 @@ class SyncImageViewer(QWidget):
 
             self.transform_changed.emit()
 
-        # 回報滑鼠位置
+        # Report cursor position
         img_x, img_y = self._widget_pos_to_image_pos(pos)
         pm_w = self.pixmap.width()
         pm_h = self.pixmap.height()


### PR DESCRIPTION
## Summary
- add unicode-safe image read/write utilities and use them when loading or saving images
- persist UI control values and load-image dialog choices between runs via QSettings
- default image browsing to the images folder when present and update UI comments to English

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a6cd1f3d083239afbae6dca6e8f14)