### PR TITLE
Hyphenate main window title to 'Dual-Illumination Defect Inspector'

### DIFF
--- a/aoi_main_window.py
+++ b/aoi_main_window.py
@@ -49,7 +49,7 @@ def save_image_unicode(path: str, image: np.ndarray) -> bool:
 class AOIInspector(QMainWindow):
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("Dual Illumination Defect Inspector")
+        self.setWindowTitle("Dual-Illumination Defect Inspector")
         self.resize(1200, 850)
 
         self.settings = QSettings("DualIllumination", "AOIInspector")


### PR DESCRIPTION
### Motivation
- Correct the main application window title to use the hyphenated form for consistent branding and readability.
- The change is a small UI polish that does not alter runtime behavior or logic.

### Description
- Update the window title string in `aoi_main_window.py` by changing the argument to `self.setWindowTitle` from "Dual Illumination Defect Inspector" to "Dual-Illumination Defect Inspector".
- This is a single-line, non-functional UI text change and does not modify any other application logic.

### Testing
- No automated tests were run for this change.
- Static review of the modified file confirms a single-line title update in `aoi_main_window.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a463437a88323a9fc60a04be0787b)